### PR TITLE
Relax criteria for what operations count as store operations.

### DIFF
--- a/llvm/include/llvm/MCA/HardwareUnits/LSUnit.h
+++ b/llvm/include/llvm/MCA/HardwareUnits/LSUnit.h
@@ -317,7 +317,7 @@ public:
   bool isStore(const InstrDesc &Desc,
                const Optional<MDMemoryAccess> &MDA) const {
     if (MDA)
-      return MDA->IsStore;
+      return MDA->IsStore || Desc.MayStore;
     else
       return Desc.MayStore;
   }


### PR DESCRIPTION
In the PowerPC architecture, the stwcx instruction is translated
into a cmpxchg instruction by QEMU and then into ld and st operations.
On the MCAD side, the stwcx instruction is statically labeled as
MayStore: true, but dynamically as IsStore: false, depending on the execution
of the program. The check in LSUnit.h is strict in the sense that stwcx, even
though it may store to memory, is still considered as generally not storing
if the dynamic information says it did not at runtime.

This minor change relaxes the aforementioned criteria for isStore,
and counts an instruction as storing if it may store as determined
statically by LLVM.