### PR TITLE
MCA: verify instruction operand count upon decode

### DIFF
--- a/llvm/lib/MCA/InstrBuilder.cpp
+++ b/llvm/lib/MCA/InstrBuilder.cpp
@@ -269,6 +269,10 @@ static void computeMaxLatency(InstrDesc &ID, const MCInstrDesc &MCDesc,
 }
 
 static Error verifyOperands(const MCInstrDesc &MCDesc, const MCInst &MCI) {
+  if (MCI.getNumOperands() < MCDesc.getNumOperands()) {
+    return make_error<InstructionError<MCInst>>(
+        "Decoded instruction is missing operands.", MCI);
+  }
   // Count register definitions, and skip non register operands in the process.
   unsigned I, E;
   unsigned NumExplicitDefs = MCDesc.getNumDefs();


### PR DESCRIPTION
If an illegal instruction is decoded, it can have fewer operands than expected, which leads to a very large allocation that will hang MCA. This fixes that.